### PR TITLE
EndPoint books can now use a searchTeam to narrow down by Title field

### DIFF
--- a/Library.Api/Program.cs
+++ b/Library.Api/Program.cs
@@ -83,9 +83,20 @@ app.MapPost("books", async (Book book, IBookService bookService,
  * 
  * returns ALL Books  status 200 Ok
  * , so dangerous for a large database
+ * 
+ * Overloaded this MapGet Endpoint with , string? searchTerm
+ * which makes this parameter optional (The ? is the character that makes it NULLable / optional)
+ * URL - https://localhost:7100/books?searchTerm=testing
+ * this returns all books with title of "testing" inside it.
  */
-app.MapGet("books", async (IBookService bookService) =>
+app.MapGet("books", async (IBookService bookService, string? searchTerm) =>
 {
+    if (searchTerm is not null && !string.IsNullOrWhiteSpace(searchTerm))
+    {
+        var matchedBooks = await bookService.SearchByTitleAsync(searchTerm);
+        return Results.Ok(matchedBooks);
+    }
+
     var books = await bookService.GetAllAsync();
     return Results.Ok(books);
 });
@@ -113,6 +124,9 @@ app.MapGet("books/{isbn}", async (string isbn, IBookService bookService) =>
     // i.e.              200 if it does exist  :  04 if it doesn't exit
     return book is not null ? Results.Ok(book) : Results.NotFound();
 });
+
+
+
 
 // DB Init Here
 

--- a/Library.Api/Services/BookService.cs
+++ b/Library.Api/Services/BookService.cs
@@ -46,19 +46,24 @@ namespace Library.Api.Services
             return await connection.QueryAsync<Book>("SELECT * FROM Books");
         }
 
-        public Task<bool> DeleteAsync(string isbn)
-        {
-            throw new NotImplementedException();
-        }
-
         public async Task<IEnumerable<Book>> SearchByTitleAsync(string searchTerm)
         {
-            throw new NotImplementedException();
+            using var connection = await _connectionFactory.CreateConnectionAsync();
+            return await connection.QueryAsync<Book>(
+                "SELECT *" +
+                " FROM Books" +
+                " WHERE Title LIKE '%' || @SearchTerm || '%'",
+                new { SearchTerm = searchTerm });
         }
 
         public async Task<bool> UpdateAsync(Book book)
         {
             throw new NotImplementedException();
         }
+        public Task<bool> DeleteAsync(string isbn)
+        {
+            throw new NotImplementedException();
+        }
+
     }
 }


### PR DESCRIPTION
EndPoint books can now use a searchTeam to narrow down by Title field.

Finished added overload to method MapGet for "books" EndPoint code.  MapGet now calls SearchByTitleAsync BookService if the books EndPoint URL adds a "searchTerm" to search for wildcard string in Book title field.

The EndPoint URL for this is:
https://localhost:7100/books?searchTerm=Test

this works even with space in between Testing and Title
https://localhost:7100/books?searchTerm=Testing title


URL string sections summarized in this example by ChatGPT:

1 - https:// is the scheme.
2 - localhost (or in real world ExampleWebSite.com) is the host.
3 - :7100 is the port.
4 - /books is the path.  Sometimes called the Route.  See below for more Route details:
5 - ?searchTerm=Testing  is the query string.
6 - If present in a URL, "#section1" is called a fragment.

Here is Route details again but from Minimal API framework:

- "api/products": This is a route that can be mapped to a specific HTTP verb and handler directly within the app's configuration.
-  "products": Similar to the controller-based approach, this is a specific part of the route that determines which handler gets executed when a request is made to that path.

Route details:  (Controllers are not in Minimal API code such as this, but this is what ChatGPT stated, I forgot to limit it to Minimal API, why not, I'll ask it now to redo from a Minimal API framework.  )
- "/books": This could be a route defined in an ASP.NET Core controller.  It specifies that when a request is made to this URL path, it should be handled by the corresponding action method in the controller.
- "/books": When used within a controller marked with a [Route("api")] attribute, 
   e.g. "products" can be an action method route, making the full route "api/products".
